### PR TITLE
Add method to define language in RecaptchaType

### DIFF
--- a/Form/Type/RecaptchaType.php
+++ b/Form/Type/RecaptchaType.php
@@ -145,4 +145,14 @@ class RecaptchaType extends AbstractType
     {
         return $this->publicKey;
     }
+
+    /**
+     * Set language.
+     */
+    public function setLanguage($language)
+    {
+        $this->language = $language;
+
+        return $this;
+    }
 }


### PR DESCRIPTION
This PR adds a new method to the RecaptchaType that allows to define the language after the service has been initialized.